### PR TITLE
 Negative sign in gaps values should be valid syntax

### DIFF
--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -54,7 +54,7 @@ syn match i3ConfigInitialize /^\s*set\s\+.*$/ contains=i3ConfigVariable,i3Config
 
 " Gaps
 syn keyword i3ConfigGapStyleKeyword inner outer horizontal vertical top right bottom left current all set plus minus toggle contained
-syn match i3ConfigGapStyle /^\s*\(gaps\)\s\+\(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+(-\?\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,number,i3ConfigVariable
+syn match i3ConfigGapStyle /^\s*\(gaps\)\s\+\(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+\(-\?\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,number,i3ConfigVariable
 syn keyword i3ConfigSmartGapKeyword on inverse_outer contained
 syn match i3ConfigSmartGap /^\s*smart_gaps\s\+\(on\|inverse_outer\)\s\?$/ contains=i3ConfigSmartGapKeyword
 syn keyword i3ConfigSmartBorderKeyword on no_gaps contained

--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -54,7 +54,7 @@ syn match i3ConfigInitialize /^\s*set\s\+.*$/ contains=i3ConfigVariable,i3Config
 
 " Gaps
 syn keyword i3ConfigGapStyleKeyword inner outer horizontal vertical top right bottom left current all set plus minus toggle contained
-syn match i3ConfigGapStyle /^\s*\(gaps\)\s\+\(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+\(\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,number,i3ConfigVariable
+syn match i3ConfigGapStyle /^\s*\(gaps\)\s\+\(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+(-\?\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,number,i3ConfigVariable
 syn keyword i3ConfigSmartGapKeyword on inverse_outer contained
 syn match i3ConfigSmartGap /^\s*smart_gaps\s\+\(on\|inverse_outer\)\s\?$/ contains=i3ConfigSmartGapKeyword
 syn keyword i3ConfigSmartBorderKeyword on no_gaps contained

--- a/test.i3config
+++ b/test.i3config
@@ -168,6 +168,7 @@ set_from_resource $black i3wm.color0 #000000
 # 29) gaps
 gaps inner 1
 gaps outer 2
+gaps outer -1
 gaps left 2
 gaps top 2
 gaps right 2


### PR DESCRIPTION
i3-gaps config allows negative gap size values, since these are in some cases added to other values (e.g. outer gap size is added to inner gap size in determining overall size at the edges of the screen); I have updated the relevant regex to allow for a "-" sign.