### PR TITLE
Add Sway support

### DIFF
--- a/ftdetect/i3config.vim
+++ b/ftdetect/i3config.vim
@@ -1,4 +1,4 @@
 aug i3config#ft_detect
     au!
-    au BufNewFile,BufRead .i3.config,i3.config,*.i3config,*.i3.config set filetype=i3config
+    au BufNewFile,BufRead .i3.config,i3.config,*.i3config,*.i3.config,*sway/config set filetype=i3config
 aug end

--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -183,6 +183,10 @@ syn region i3ConfigBlock start=+.*s\?{$+ end=+^}$+ contains=i3ConfigBlockKeyword
 " Line continuation
 syn region i3ConfigLineCont start=/^.*\\$/ end=/^.*$/ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable transparent keepend extend
 
+" Include sway config file
+syn keyword swayConfigInclude include contained
+syn match swayConfigFile /^include\s\(\~\/.*$\|\/.*$\|\.\{1,2}\/.*$\)/ contains=swayInclude
+
 " Define the highlighting.
 hi! def link i3ConfigError                           Error
 hi! def link i3ConfigTodo                            Todo
@@ -255,5 +259,7 @@ hi! def link i3ConfigDrawingMarksKeyword             Identifier
 hi! def link i3ConfigBlockKeyword                    Identifier
 hi! def link i3ConfigVariable                        Statement
 hi! def link i3ConfigArbitraryCommand                Type
+hi! def link swayConfigInclude                       Identifier
+hi! def link swayConfigFile                          Constant
 
 let b:current_syntax = "i3config"

--- a/test.i3config
+++ b/test.i3config
@@ -15,6 +15,8 @@ new_float normall
 hade_edge_borders both
 exec_ chromium
 mouse_wraping none
+include config_file
+include .../config_file
 
 # 2) COMMENT
 # This is a comment
@@ -273,3 +275,9 @@ smart_borders no_gaps
 title_align left
 title_align right
 title_align center
+
+# 36) sway config file include
+include ~/.config/sway/config
+include /.config/sway/config
+include ./sway/config
+include ../sway/config


### PR DESCRIPTION
Since sway supports i3 syntax, it would be nice to have support for the config files. I've added support for sway config file detection. There is also support for the `include` keyword to load sway files that is not a part of i3.
Thanks for the plugin!