### PR TITLE
Detect "i3/config" filename

### DIFF
--- a/ftdetect/i3config.vim
+++ b/ftdetect/i3config.vim
@@ -1,4 +1,4 @@
 aug i3config#ft_detect
     au!
-    au BufNewFile,BufRead .i3.config,i3.config,*.i3config,*.i3.config,*sway/config,*.swayconfig,*.sway.config,sway.config,*sway/config set filetype=i3config
+    au BufNewFile,BufRead *i3/config,*i3config,*i3.config,*sway/config,*swayconfig,*sway.config set filetype=i3config
 aug end


### PR DESCRIPTION
- Detect "i3/config" which is the default for i3
- Remove redundant filenames.